### PR TITLE
GDPR comply

### DIFF
--- a/order-delivery-date-for-woocommerce/orddd-lite-privacy.php
+++ b/order-delivery-date-for-woocommerce/orddd-lite-privacy.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Order Delivery Date for WooCommerce Lite
+ *
+ * GDPR related fixes. 
+ *
+ * @author      Tyche Softwares
+ * @package     Order-Delivery-Date-Lite-for-WooCommerce/Privacy
+ * @since       1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+include_once( dirname( __FILE__ ) . '/orddd-lite-common.php' );
+
+/**
+ * GDPR related fixes. 
+ *
+ * @class orddd_lite_privacy
+ */
+class orddd_lite_privacy {
+	/**
+	 * Default Constructor
+	 *
+	 * @since 3.5
+	 */
+
+	public function __construct() {
+		add_filter( "woocommerce_privacy_export_order_personal_data_props", array( &$this, "orddd_lite_privacy_export_order_personal_data_props" ), 10, 2 );
+        add_filter( "woocommerce_privacy_export_order_personal_data_prop", array( &$this, "orddd_lite_privacy_export_order_personal_data_prop_callback" ), 10, 3 );
+	}
+
+	function orddd_lite_privacy_export_order_personal_data_props( $props_to_export, $order ) {
+        $my_key_value   = array( 'delivery_details' => __( 'Delivery Date', 'order-delivery-date' ) );
+        $key_pos        = array_search( 'items', array_keys( $props_to_export ) );
+        
+        if ( $key_pos !== false ) {
+            $key_pos++;
+            
+            $second_array       = array_splice( $props_to_export, $key_pos );        
+            $props_to_export    = array_merge( $props_to_export, $my_key_value, $second_array );
+        }
+
+        return $props_to_export;
+    }  
+
+    function orddd_lite_privacy_export_order_personal_data_prop_callback( $value, $prop, $order ) {
+        if ( $prop == "delivery_details" ) {
+            $delivery_date = orddd_lite_common::orddd_lite_get_order_delivery_date( $order->get_id() );
+            $value = $delivery_date;           
+        }
+        return $value;
+    }
+}
+
+$orddd_lite_privacy = new orddd_lite_privacy();

--- a/order-delivery-date-for-woocommerce/order_delivery_date.php
+++ b/order-delivery-date-for-woocommerce/order_delivery_date.php
@@ -30,6 +30,7 @@ include_once( 'orddd-lite-common.php' );
 include_once( 'orddd-lite-settings.php' );
 include_once( 'orddd-lite-process.php' );
 include_once( 'filter.php' );
+include_once( 'orddd-lite-privacy.php' );
 //include_once( 'orddd-lite-pro-notices.php' );
 
 /**


### PR DESCRIPTION
Add Delivery Date information into the data exported for the users from Export Personal Data WordPress option added in WordPress verson 4.9.6