### PR TITLE
Fix #279:MDT was not applied on time slots

### DIFF
--- a/includes/class-orddd-lite-common.php
+++ b/includes/class-orddd-lite-common.php
@@ -699,7 +699,7 @@ class Orddd_Lite_Common {
 			$delivery_date   = date( 'n-j-Y', strtotime( $current_date ) ); //phpcs:ignore
 		}
 
-		$min_hour_in_sec = get_option( 'orddd_lite_minimumOrderDays' );
+		$min_hour_in_sec = '' !== get_option( 'orddd_lite_minimumOrderDays' ) ? get_option( 'orddd_lite_minimumOrderDays' ) * 60 * 60 : 0;
 		$min_date_array  = orddd_lite_common::get_min_date( $min_hour_in_sec, $holidays_str, $lockout_str );
 
 		if ( 'checked' === get_option( 'orddd_lite_time_slot_asap' ) ) {


### PR DESCRIPTION
All the timeslots for a date were displayed even if the MDT was applied and they should have been disabled.