### PR TITLE
Version 3.11.2

### DIFF
--- a/order_delivery_date.php
+++ b/order_delivery_date.php
@@ -4,13 +4,13 @@
  * Plugin URI: https://www.tychesoftwares.com/store/premium-plugins/order-delivery-date-for-woocommerce-pro-21/
  * Description: This plugin allows customers to choose their preferred Order Delivery Date during checkout.
  * Author: Tyche Softwares
- * Version: 3.11.1
+ * Version: 3.11.2
  * Author URI: https://www.tychesoftwares.com/
  * Contributor: Tyche Softwares, https://www.tychesoftwares.com/
  * Text Domain: order-delivery-date
  * Requires PHP: 5.6
  * WC requires at least: 3.0.0
- * WC tested up to: 4.4.1
+ * WC tested up to: 4.5.1
  *
  * @package  Order-Delivery-Date-Lite-for-WooCommerce
  */
@@ -20,7 +20,7 @@
  *
  * @since 1.0
  */
-$wpefield_version = '3.11.1';
+$wpefield_version = '3.11.2';
 
 /**
  * Include the require files
@@ -290,7 +290,7 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 		 */
 		public function orddd_lite_update_db_check() {
 			global $wpefield_version;
-			if ( '3.11.1' === $wpefield_version ) {
+			if ( '3.11.2' === $wpefield_version ) {
 				self::orddd_lite_update_install();
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -243,6 +243,11 @@ Currently, it is not possible to add different delivery settings for different s
 
 == Changelog ==
 
+= 3.11.2 (11.09.2020) =
+* Fix - The first available date was coming wrong when the 'Apply Minimum Delivery Time for non working weekdays' setting was enabled.
+* Fix - Minimum Delivery time was not being calculated on the time slots.
+* Fix - Wrong date was being auto-populated on checkout page.
+
 = 3.11.1 (04.09.2020) =
 * Fix - 'Array' word was being displayed in the order emails.
 * Fix - The delivery date field was not placed correctly when the setting 'Field placement on the Checkout page' was set to 'Between Your Order & Payment Section'.


### PR DESCRIPTION
* Fix - The first available date was coming wrong when the 'Apply Minimum Delivery Time for non working weekdays' setting was enabled.
* Fix - Minimum Delivery time was not being calculated on the time slots.
* Fix - Wrong date was being auto-populated on checkout page.
