### PR TITLE
Fix #286:The checkout page hanged when current day was selected

### DIFF
--- a/js/orddd-lite-initialize-datepicker.js
+++ b/js/orddd-lite-initialize-datepicker.js
@@ -314,6 +314,8 @@ function minimum_date_to_set( delay_days ) {
 				if ( day_check == '' ) {
 					delay_days.setDate( delay_days.getDate() + 1 );
 					delay_time = delay_days.getTime();
+					delay_weekday   = delay_days.getDay();
+
 					current_day.setDate( current_day.getDate() + 1 );
 					current_time    = current_day.getTime();
 					current_weekday = current_day.getDay();
@@ -510,6 +512,7 @@ function avd( date ) {
 					if ( day_check == '' ) {
 						delay_days.setDate( delay_days.getDate() + 1 );
 						delay_time = delay_days.getTime();
+						delay_weekday   = delay_days.getDay();
 						current_day.setDate( current_day.getDate() + 1 );
 						current_time    = current_day.getTime();
 						current_weekday = current_day.getDay();

--- a/readme.txt
+++ b/readme.txt
@@ -69,7 +69,7 @@ You can check the detailed difference between Pro and Lite version **[here](http
 
 **Following features are available in PRO version:**
 
-* Ability to allow the customer to select <strong>Delivery Time along with Delivery Date</strong>.
+* Create <strong>recurring delivery schedules</strong> using WooCommerce Subscriptions plugin.
 * <strong>Same-day & Next-day delivery</strong> with cut-off time.
 * <strong>Two-way deliveries sync</strong> with Google Calendar.
 * Create Delivery <strong>Settings by Shipping Zones & Shipping Classes</strong>.


### PR DESCRIPTION
When the current day was enabled in the weekdays, the checkout page was becoming unresponsive due to an infinite loop.

Also updated readme.txt