### PR TITLE
Fix #196:NaN was coming for the date when translated in the google chrome

### DIFF
--- a/js/orddd-lite-initialize-datepicker.js
+++ b/js/orddd-lite-initialize-datepicker.js
@@ -468,7 +468,10 @@ function chd( date ) {
  * @returns {object} options object to update the datepicker
  * @since 1.0
  */
-function avd( date ) {
+function avd( date, inst ) {
+	// Added to not translate the calendar when the site is translated using Google Translator. 
+	inst.dpDiv.addClass( 'notranslate' );
+	
 	var disabledDays = eval( "[" + jQuery( "#orddd_lite_holidays" ).val() + "]" );
 	var holidays     = [];
 	for ( i = 0; i < disabledDays.length; i++ ) {


### PR DESCRIPTION
When we translates page from Google Chrome, delivery date was showing as "NaN Undefined, NaN" 

[do-not-scan]