### PR TITLE
Fix #312:Fatal error was coming when installing plugin with PHP 7.3

### DIFF
--- a/order_delivery_date.php
+++ b/order_delivery_date.php
@@ -324,7 +324,7 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 		 */
 		public function orddd_lite_capabilities() {
 			$role = get_role( 'shop_manager' );
-			if ( '' !== $role ) {
+			if ( isset( $role ) && '' !== $role ) {
 				$role->add_cap( 'manage_options' );
 			}
 		}


### PR DESCRIPTION
A fatal error was displayed when the plugin was installed with PHP 7.3 