### PR TITLE
Fixed the issue of not getting translating auto populate date

### DIFF
--- a/order_delivery_date.php
+++ b/order_delivery_date.php
@@ -412,21 +412,6 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 				wp_enqueue_style( 'datepicker', plugins_url( '/css/datepicker.css', __FILE__ ), '', $wpefield_version, false );
 
 				wp_dequeue_script( 'initialize-datepicker' );
-				wp_enqueue_script( 'initialize-datepicker-orddd', plugins_url( '/js/orddd-lite-initialize-datepicker.js', __FILE__ ), '', $wpefield_version, false );
-				$is_admin = is_admin() ? true : false;
-
-				$js_args = array(
-					'clearText'   => __( 'Clear', 'order-delivery-date' ),
-					'holidayText' => __( 'Holiday', 'order-delivery-date' ),
-					'bookedText'  => __( 'Booked', 'order-delivery-date' ),
-					'selectText'  => __( 'Select a time slot', 'order-delivery-date' ),
-					'asapText'    => __( 'As Soon As Possible', 'order-delivery-date' ),
-					'NAText'      => __( 'No time slots are available', 'order-delivery-date' ),
-					'wooVersion'  => get_option( 'woocommerce_version' ),
-					'is_admin'    => $is_admin,
-					'bookedText'  => __( 'Booked', 'order-delivery-date' ),
-				);
-				wp_localize_script( 'initialize-datepicker-orddd', 'jsL10n', $js_args );
 
 				if ( isset( $_GET['lang'] ) && '' !== $_GET['lang'] && null !== $_GET['lang'] ) {
 					$language_selected = wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['lang'] ) ) );
@@ -448,6 +433,22 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 				}
 
 				wp_enqueue_script( $language_selected, plugins_url( "/js/i18n/jquery.ui.datepicker-$language_selected.js", __FILE__ ), array( 'jquery', 'jquery-ui-datepicker' ), $wpefield_version, false );
+
+				wp_enqueue_script( 'initialize-datepicker-orddd', plugins_url( '/js/orddd-lite-initialize-datepicker.js', __FILE__ ), '', $wpefield_version, false );
+				$is_admin = is_admin() ? true : false;
+
+				$js_args = array(
+					'clearText'   => __( 'Clear', 'order-delivery-date' ),
+					'holidayText' => __( 'Holiday', 'order-delivery-date' ),
+					'bookedText'  => __( 'Booked', 'order-delivery-date' ),
+					'selectText'  => __( 'Select a time slot', 'order-delivery-date' ),
+					'asapText'    => __( 'As Soon As Possible', 'order-delivery-date' ),
+					'NAText'      => __( 'No time slots are available', 'order-delivery-date' ),
+					'wooVersion'  => get_option( 'woocommerce_version' ),
+					'is_admin'    => $is_admin,
+					'bookedText'  => __( 'Booked', 'order-delivery-date' ),
+				);
+				wp_localize_script( 'initialize-datepicker-orddd', 'jsL10n', $js_args );
 			}
 		}
 


### PR DESCRIPTION
In this commit, I have fixed it. Fix #328

This issue is happening due to `orddd-lite-initialize-datepicker.js` file loading earlier than the regional datepicker file so it only showing the date in English when the page loads.