### PR TITLE
Fixed the issue of not showing date in edit-order

### DIFF
--- a/includes/class-orddd-lite-admin-delivery.php
+++ b/includes/class-orddd-lite-admin-delivery.php
@@ -28,7 +28,6 @@ class Orddd_Lite_Admin_Delivery {
 	 * @since 3.13.0
 	 */
 	public function __construct() {
-		add_action( 'woocommerce_saved_order_items', array( &$this, 'orddd_woocommerce_saved_order_items' ), 10, 2 );
 		add_action( 'wp_ajax_save_delivery_dates', array( &$this, 'save_delivery_dates' ) );
 		// Display Order Delivery Date meta box on Add/Edit Orders Page.
 		if ( 'on' === get_option( 'orddd_lite_enable_delivery_date' ) ) {

--- a/js/orddd-lite-initialize-datepicker.js
+++ b/js/orddd-lite-initialize-datepicker.js
@@ -6,7 +6,7 @@
  */
 jQuery( document ).ready( function() {
 
-		if ( '1' === jsL10n.is_admin ) {
+		if ( '1' === jsL10n.is_admin && jQuery('#orddd_lite_holiday_color').length > 0 ) {
 			// Add Color Picker to all inputs that have 'color-field' class
 			jQuery( '.cpa-color-picker' ).wpColorPicker();
 		}


### PR DESCRIPTION
In this commit, I have fixed this issue. Fix #365, #366

There is one jQuery error and due to that error, the click event of an update button is not firing and hence it is not saving the delivery date as mentioned in issue #366 so both the issues will be fixed with this PR.