### PR TITLE
Fixed the extra space issue between Specific Delivery Date Text and Specific delivery dates setup box.

### DIFF
--- a/css/order-delivery-date.css
+++ b/css/order-delivery-date.css
@@ -94,3 +94,7 @@ table.form-table #orddd_lite_ics_url_list .orddd_lite_ics_feed_url {
 .add-timeslot {
 	margin-top: 12px;
 }
+
+#orddd_delivery_dates_list .tablenav {
+	display: none;
+}

--- a/includes/settings/class-orddd-lite-settings.php
+++ b/includes/settings/class-orddd-lite-settings.php
@@ -1611,7 +1611,7 @@ class Orddd_Lite_Settings {
 							print( '</form>
 						</div>
 					</div>' );
-					echo "<div class='orddd-col-right'><h3 id='delivery_date_table_head'>" . esc_attr_e( 'Specific Delivery Dates', 'order-delivery-date' ) . '</h3>';
+					echo "<div class='orddd-col-right'><h2 id='delivery_date_table_head'>" . esc_attr__( 'Specific Delivery Dates', 'order-delivery-date' ) . '</h2>';
 					include_once 'class-orddd-lite-view-specific-table.php';
 					$orddd_table = new ORDDD_Lite_View_Specific_Table();
 					$orddd_table->orddd_prepare_items();


### PR DESCRIPTION
In this commit, I have fixed this issue. Fix #395