### PR TITLE
Version 3.17.3

### DIFF
--- a/order_delivery_date.php
+++ b/order_delivery_date.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.tychesoftwares.com/store/premium-plugins/order-delivery-date-for-woocommerce-pro-21/
  * Description: This plugin allows customers to choose their preferred Order Delivery Date during checkout.
  * Author: Tyche Softwares
- * Version: 3.17.2
+ * Version: 3.17.3
  * Author URI: https://www.tychesoftwares.com/
  * Contributor: Tyche Softwares, https://www.tychesoftwares.com/
  * Text Domain: order-delivery-date
@@ -20,7 +20,7 @@
  *
  * @since 1.0
  */
-$wpefield_version = '3.17.2';
+$wpefield_version = '3.17.3';
 
 /**
  * Template path.
@@ -304,7 +304,7 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 		 */
 		public function orddd_lite_update_db_check() {
 			global $wpefield_version;
-			if ( '3.17.2' === $wpefield_version ) {
+			if ( '3.17.3' === $wpefield_version ) {
 				self::orddd_lite_update_install();
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -163,6 +163,8 @@ Option 3:
 7. Delivery Date will be displayed on the Orders page in a new column titled "Delivery Date"
 
 == Changelog ==
+= 3.17.3 (05.05.2022) =
+* Fix - Cut-off time error was appearing on checkout page when 'Select Time slot' or 'Timeslot Not Available' is chosen.
 
 = 3.17.2 (05.05.2022) =
 * Fix - Cut-off time error was appearing on checkout page when plugin was not used and no date sent.


### PR DESCRIPTION
Fix cut-off time error for 'Select time slot' and 'Timeslots not available.
[do-not-scan]