### PR TITLE
fix-467

### DIFF
--- a/includes/class-orddd-lite-process.php
+++ b/includes/class-orddd-lite-process.php
@@ -199,7 +199,7 @@ class Orddd_Lite_Process {
 				}
 			}
 
-			do_action( 'orddd_after_timeslot_update', $time_slot );
+			do_action( 'orddd_after_timeslot_update', $time_slot, $order_id );
 		}
 	}
 


### PR DESCRIPTION
We have add '$order_id' to the 'orddd_after_timeslot_update' action hook to support different time zone as requested by user.
fix #467 