### PR TITLE
Fixes for 3.25.0

### DIFF
--- a/includes/component/plugin-tracking/ts-tracking.php
+++ b/includes/component/plugin-tracking/ts-tracking.php
@@ -240,12 +240,14 @@ class Orddd_Lite_TS_Tracking {
 	 * @access public
 	 */
 	public static function ts_admin_notices_scripts() {
+		global $wpefield_version;
+
 		$nonce = wp_create_nonce( 'tracking_notice' );
 			wp_enqueue_script(
 				'orddd_ts_dismiss_notice',
 				self::$ts_file_path . '/js/tyche-dismiss-tracking-notice.js',
 				array( 'jquery' ),
-				'4.5.6',
+				$wpefield_version,
 				false
 			);
 

--- a/order_delivery_date.php
+++ b/order_delivery_date.php
@@ -177,7 +177,7 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 			add_action( 'woocommerce_cart_calculate_fees', array( 'Orddd_Lite_Process', 'orddd_lite_add_delivery_date_fee' ) );
 
 			// Ajax calls.
-			add_action( 'admin_init', array( &$this, 'orddd_lite_add_component_file' ) );
+			add_action( 'init', array( &$this, 'orddd_lite_add_component_file' ), 1 );
 
 			// It will add the actions for the components.
 			if ( is_admin() ) {


### PR DESCRIPTION
In this commit, I have fixed the following issues
1. The Upgrade to Pro submenu was not coming
2. The tyche-dismiss-tracking-notice.js file was loaded with a static version number hence the caching issue.