### PR TITLE
Add nonce and capability checks to save_delivery_dates AJAX action

### DIFF
--- a/includes/class-orddd-lite-admin-delivery.php
+++ b/includes/class-orddd-lite-admin-delivery.php
@@ -153,6 +153,16 @@ class Orddd_Lite_Admin_Delivery {
 	public static function save_delivery_dates() {
 		global $wpdb, $orddd_weekdays;
 
+		if ( ! check_ajax_referer( 'orddd_save_delivery_dates', 'security', false ) ) {
+			echo esc_html__( 'Invalid request. Please refresh the page and try again.', 'order-delivery-date-for-woocommerce' );
+			wp_die();
+		}
+
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
+			echo esc_html__( 'You are not authorized to update order delivery dates.', 'order-delivery-date-for-woocommerce' );
+			wp_die();
+		}
+
 		$delivery_details_updated = 'yes';
 		$notes_array              = array();
 
@@ -438,6 +448,7 @@ class Orddd_Lite_Admin_Delivery {
 			$admin_lite_params['orddd_lite_min_date_set']         = esc_attr( $min_date_array['min_date'] );
 			$admin_lite_params['orddd_lite_field_label']          = esc_attr( $date_field_label );
 			$admin_lite_params['orddd_lite_timeslot_field_label'] = esc_attr( $time_field_label );
+			$admin_lite_params['security']                        = wp_create_nonce( 'orddd_save_delivery_dates' );
 			return $admin_lite_params;
 		}
 	}

--- a/js/orddd-lite-initialize-datepicker.js
+++ b/js/orddd-lite-initialize-datepicker.js
@@ -1024,6 +1024,7 @@ var data = {
 	orddd_post_type: orddd_lite_admin_params.orddd_post_type,
 	orddd_notify_customer: notify,
 	orddd_charges: jQuery( '#del_charges' ).val(),
+	security: orddd_lite_admin_params.security,
 	action: "save_delivery_dates"
 };
 
@@ -1047,6 +1048,13 @@ if( orddd_lite_admin_params.orddd_lite_admin_url != '' && typeof( orddd_lite_adm
 			},3000 );
 		} else if ( validations[ 1 ] == "no" && ( ( orddd_lite_admin_params.orddd_lite_enable_time_slot == "on" && orddd_lite_admin_params.orddd_lite_time_slot_mandatory == "checked" ) ) ) {
 			jQuery( "#orddd_lite_update_notice" ).html( orddd_lite_admin_params.orddd_lite_timeslot_field_label + " is mandatory." );
+			jQuery( "#orddd_lite_update_notice" ).attr( "color", "red" );
+			jQuery( "#orddd_lite_update_notice" ).fadeIn();
+			setTimeout( function() {
+				jQuery( "#orddd_lite_update_notice" ).fadeOut();
+			},3000 );
+		} else {
+			jQuery( "#orddd_lite_update_notice" ).html( response );
 			jQuery( "#orddd_lite_update_notice" ).attr( "color", "red" );
 			jQuery( "#orddd_lite_update_notice" ).fadeIn();
 			setTimeout( function() {


### PR DESCRIPTION
This PR fixes a Broken Access Control vulnerability in the `save_delivery_dates()` function of `class-orddd-lite-admin-delivery.php`.

1. Added CSRF protection using `check_ajax_referer()`
2. Added capability check `(current_user_can( 'edit_shop_orders' ))` to ensure only authorized users can update delivery dates.

This prevents unauthenticated attackers from modifying delivery dates via forged requests.

**Testing Instructions**

1. Go to WooCommerce → Orders → Edit Order.
2. If you are logged in as an Admin user, you will be able to update the delivery date and time slot successfully.
3. If the request is missing/invalid nonce or the user does not have `edit_shop_orders` capability, the update will be rejected with an error message.