### PR TITLE
Fix PHP Deprecated Warnings by Adding Null Checks Before strtotime()

### DIFF
--- a/includes/class-orddd-lite-process.php
+++ b/includes/class-orddd-lite-process.php
@@ -780,7 +780,7 @@ class Orddd_Lite_Process {
 				$timeslot_log_arr = json_decode( $timeslot_log_str );
 			}
 
-			$date_to_check = date( 'n-j-Y', strtotime( $delivery_date ) ); //phpcs:ignore
+			$date_to_check = ! empty( $delivery_date ) ? date( 'n-j-Y', strtotime( $delivery_date ) ) : ''; //phpcs:ignore
 			foreach ( $timeslot_log_arr as $k => $v ) {
 				$ft = $v->fh . ':' . trim( $v->fm );
 				if ( $v->th != 00 ) { //phpcs:ignore
@@ -790,7 +790,7 @@ class Orddd_Lite_Process {
 					$time_slot_key = $ft;
 				}
 
-				$weekday = date( 'w', strtotime( $delivery_date ) ); //phpcs:ignore
+				$weekday = ! empty( $delivery_date ) ? date( 'w', strtotime( $delivery_date ) ) : ''; //phpcs:ignore
 				if ( gettype( json_decode( $v->dd ) ) === 'array' && count( json_decode( $v->dd ) ) > 0 ) {
 					$dd = json_decode( $v->dd );
 					foreach ( $dd as $dkey => $dval ) {


### PR DESCRIPTION
This update resolves PHP 8.1+ deprecated warnings caused by passing `NULL` values to `strtotime()`. Added safe` ! empty() `checks for `$delivery_date` and time slot values before calling `strtotime()`. 

Fix #645