### PR TITLE
Added nonce verification to Time Slots bulk delete action

### DIFF
--- a/includes/settings/class-orddd-lite-settings.php
+++ b/includes/settings/class-orddd-lite-settings.php
@@ -1417,6 +1417,13 @@ class Orddd_Lite_Settings {
 
 			if ( ( isset( $_POST['action'] ) && sanitize_text_field( $_POST['action'] ) == 'orddd_delete' ) || ( isset( $_POST['action2'] ) && sanitize_text_field( $_POST['action2'] ) == 'orddd_delete' ) ) { //phpcs:ignore
 
+				if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
+					return;
+				}
+				if ( ! isset( $_POST['orddd_bulk_delete_nonce'] ) || ! wp_verify_nonce( $_POST['orddd_bulk_delete_nonce'], 'orddd_bulk_delete_action' ) ) { //phpcs:ignore
+					wp_die( 'Security check failed (invalid nonce).' );
+				}
+
 				$time_slot_to_delete = array();
 				if ( isset( $_POST['time_slot'] ) ) { //phpcs:ignore
 					$time_slot_to_delete = $_POST['time_slot']; //phpcs:ignore

--- a/includes/settings/class-orddd-lite-view-time-slots.php
+++ b/includes/settings/class-orddd-lite-view-time-slots.php
@@ -71,6 +71,7 @@ class ORDDD_Lite_View_Time_Slots extends WP_List_Table {
 	 * @since 3.11.0
 	 **/
 	public function column_cb( $item ) {
+		wp_nonce_field( 'orddd_bulk_delete_action', 'orddd_bulk_delete_nonce' );
 		$dd = '';
 		if ( isset( $item->dd ) ) {
 			$dd = $item->dd;


### PR DESCRIPTION
This update secures the bulk delete operation in the Time Slots admin table by adding WordPress nonce generation in the form and validating it inside `process_bulk_action()`. This prevents unauthorized deletion requests. 
Fix #648