### PR TITLE
Add nonce verification for Holidays and Block Timeslots actions

### DIFF
--- a/includes/settings/class-orddd-lite-settings.php
+++ b/includes/settings/class-orddd-lite-settings.php
@@ -1392,6 +1392,13 @@ class Orddd_Lite_Settings {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ( isset( $_GET['page'] ) && 'order_delivery_date_lite' === $_GET['page'] ) && ( isset( $_GET['tab'] ) && 'general_settings' === $_GET['tab'] && ( isset( $_GET['section'] ) && sanitize_text_field( $_GET['section'] ) == 'holidays' ) ) && ( ( isset( $_GET['action'] ) && 'orddd_lite_delete' === $_GET['action'] ) || ( isset( $_GET['action2'] ) && 'orddd_lite_delete' === $_GET['action2'] ) ) ) { //phpcs:ignore
 
+			if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
+					return;
+			}
+			if ( ! isset( $_GET['orddd_lite_holidays_nonce'] ) || ! wp_verify_nonce( $_GET['orddd_lite_holidays_nonce'], 'orddd_lite_holidays_nonce' ) ) { //phpcs:ignore
+				wp_die( 'Security check failed (invalid nonce).' );
+			}
+
 			$holiday = array();
 			// phpcs:ignore WordPress.Security.NonceVerification
 			if ( isset( $_GET['holiday'] ) ) {
@@ -1522,6 +1529,13 @@ class Orddd_Lite_Settings {
 		if ( ( isset( $_POST['page'] ) && sanitize_text_field( $_POST['page'] ) == 'order_delivery_date_lite' ) && ( isset( $_POST['tab'] ) && sanitize_text_field( $_POST['tab'] ) == 'general_settings' ) && ( isset( $_POST['section'] ) && sanitize_text_field( $_POST['section'] ) == 'block_time_slot_settings' ) ) { //phpcs:ignore
 
 			if ( ( isset( $_POST['action'] ) && sanitize_text_field( $_POST['action'] ) == 'orddd_delete' ) || ( isset( $_POST['action2'] ) && sanitize_text_field( $_POST['action2'] ) == 'orddd_delete' ) ) { //phpcs:ignore
+
+				if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
+					return;
+				}
+				if ( ! isset( $_POST['orddd_block_time_slot_nonce'] ) || ! wp_verify_nonce( $_POST['orddd_block_time_slot_nonce'], 'orddd_block_time_slot_nonce' ) ) { //phpcs:ignore
+					wp_die( 'Security check failed (invalid nonce).' );
+				}
 				$block_time_slot_to_delete = array();
 				if ( isset( $_POST['block_time_slot'] ) ) { //phpcs:ignore
 					$block_time_slot_to_delete = $_POST['block_time_slot']; //phpcs:ignore

--- a/includes/settings/class-orddd-lite-view-disable-time-slots.php
+++ b/includes/settings/class-orddd-lite-view-disable-time-slots.php
@@ -68,6 +68,7 @@ class ORDDD_Lite_View_Disable_Time_Slots extends WP_List_Table {
 	 * @since 3.11.0
 	 **/
 	public function column_cb( $item ) {
+		wp_nonce_field( 'orddd_block_time_slot_nonce', 'orddd_block_time_slot_nonce' );
 		if ( isset( $item->disable_dd ) && '' !== $item->disable_dd ) {
 			$dd = $item->disable_dd;
 			return sprintf(

--- a/includes/settings/class-orddd-lite-view-holidays-table.php
+++ b/includes/settings/class-orddd-lite-view-holidays-table.php
@@ -66,6 +66,7 @@ class Orddd_Lite_View_Holidays_Table extends WP_List_Table {
 	 * @since 2.8
 	 **/
 	public function column_cb( $item ) {
+		wp_nonce_field( 'orddd_lite_holidays_nonce', 'orddd_lite_holidays_nonce' );
 		$row_id = '';
 		if ( isset( $item->holiday_date_stored ) && '' !== $item->holiday_date_stored ) {
 			$row_id = $item->holiday_date_stored;


### PR DESCRIPTION
This PR adds proper nonce verification for the Holidays and Block Timeslots actions in the admin settings. The change ensures that both actions validate requests securely, preventing unauthorized access and improving overall security for these admin operations. 
Fix #653 , Fix #648