### PR TITLE
Prevented a potential SQL injection issue in the Delivery Calendar event endpoint.

### DIFF
--- a/order_delivery_date.php
+++ b/order_delivery_date.php
@@ -661,7 +661,7 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 					'calendar_language'   => $language_selected,
 					'admin_url'           => get_admin_url(),
 					'ajax_url'            => get_admin_url() . 'admin-ajax.php',
-					'pluginurl'           => admin_url() . 'admin.php?action=orddd-delivery-calendar-event-json&vendor_id=0',
+					'pluginurl'           => admin_url() . 'admin.php?action=orddd-delivery-calendar-event-json&vendor_id=0&security='.wp_create_nonce( 'orddd-delivery-calendar-event-json' ),
 					'security'            => wp_create_nonce( 'orddd-delivery-calendar-event-json' ),
 					'vendor_id'           => 0,
 				);


### PR DESCRIPTION
**Cause :**
The Delivery Calendar event endpoint was registered via the init hook and constructed SQL queries by directly interpolating user-supplied request parameters (such as orderStatus and date values) into raw SQL strings. Although inputs were sanitized using sanitize_text_field(), they were not safely escaped using $wpdb->prepare(). This allowed crafted input to alter the SQL query, making the endpoint vulnerable to SQL injection. Additionally, the endpoint could be reached before proper authorization checks were enforced.

**Fix:**
Restricted the Delivery Calendar event handler to authenticated admin users only by registering it via wp_ajax_* instead of init. Added early capability and nonce validation to block unauthorized access. Refactored all SQL queries to use $wpdb->prepare() with placeholders and replaced dynamic status input with a strict whitelist of valid WooCommerce order statuses. This ensures all database queries are safely parameterized and eliminates the SQL injection vector.

Fix #680