### PR TITLE
Fixed an issue where bulk actions in Holidays, Blocked Time Slots, and Time Slot Listing generated excessively long URLs due to repeated query parameter appending.

### DIFF
--- a/includes/settings/class-orddd-lite-settings.php
+++ b/includes/settings/class-orddd-lite-settings.php
@@ -1234,6 +1234,7 @@ class Orddd_Lite_Settings {
 							<input type="hidden" name="page" value="order_delivery_date_lite" />
 							<input type="hidden" name="tab" value="general_settings" />
 							<input type="hidden" name="section" value="holidays" />
+							<input type="hidden" name="orddd_lite_holidays_nonce" value="<?php echo wp_create_nonce( 'orddd_lite_holidays_nonce' ); ?>">
 							<?php $orddd_table->display(); ?>
 						</form>
 					</div>
@@ -1294,6 +1295,7 @@ class Orddd_Lite_Settings {
 							<input type="hidden" name="page" value="order_delivery_date_lite" />
 							<input type="hidden" name="tab" value="general_settings" />
 							<input type="hidden" name="section" value="time_slot" />
+							<input type="hidden" name="orddd_bulk_delete_nonce" value="<?php echo wp_create_nonce( 'orddd_bulk_delete_nonce' ); ?>">
 							<?php $orddd_table->display(); ?>
 						</form>
 					</div>
@@ -1320,6 +1322,7 @@ class Orddd_Lite_Settings {
 								<input type="hidden" name="page" value="order_delivery_date_lite" />
 								<input type="hidden" name="tab" value="general_settings" />
 								<input type="hidden" name="section" value="block_time_slot_settings" />
+								<input type="hidden" name="orddd_block_time_slot_nonce" value="<?php echo wp_create_nonce( 'orddd_block_time_slot_nonce' ); ?>">
 								<?php $orddd_table_test->display(); ?>
 							</form>
 						</div>
@@ -1442,7 +1445,7 @@ class Orddd_Lite_Settings {
 				if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
 					return;
 				}
-				if ( ! isset( $_POST['orddd_bulk_delete_nonce'] ) || ! wp_verify_nonce( $_POST['orddd_bulk_delete_nonce'], 'orddd_bulk_delete_action' ) ) { //phpcs:ignore
+				if ( ! isset( $_POST['orddd_bulk_delete_nonce'] ) || ! wp_verify_nonce( $_POST['orddd_bulk_delete_nonce'], 'orddd_bulk_delete_nonce' ) ) { //phpcs:ignore
 					wp_die( 'Security check failed (invalid nonce).' );
 				}
 

--- a/includes/settings/class-orddd-lite-view-disable-time-slots.php
+++ b/includes/settings/class-orddd-lite-view-disable-time-slots.php
@@ -68,7 +68,6 @@ class ORDDD_Lite_View_Disable_Time_Slots extends WP_List_Table {
 	 * @since 3.11.0
 	 **/
 	public function column_cb( $item ) {
-		wp_nonce_field( 'orddd_block_time_slot_nonce', 'orddd_block_time_slot_nonce' );
 		if ( isset( $item->disable_dd ) && '' !== $item->disable_dd ) {
 			$dd = $item->disable_dd;
 			return sprintf(

--- a/includes/settings/class-orddd-lite-view-holidays-table.php
+++ b/includes/settings/class-orddd-lite-view-holidays-table.php
@@ -66,7 +66,6 @@ class Orddd_Lite_View_Holidays_Table extends WP_List_Table {
 	 * @since 2.8
 	 **/
 	public function column_cb( $item ) {
-		wp_nonce_field( 'orddd_lite_holidays_nonce', 'orddd_lite_holidays_nonce' );
 		$row_id = '';
 		if ( isset( $item->holiday_date_stored ) && '' !== $item->holiday_date_stored ) {
 			$row_id = $item->holiday_date_stored;

--- a/includes/settings/class-orddd-lite-view-time-slots.php
+++ b/includes/settings/class-orddd-lite-view-time-slots.php
@@ -71,7 +71,6 @@ class ORDDD_Lite_View_Time_Slots extends WP_List_Table {
 	 * @since 3.11.0
 	 **/
 	public function column_cb( $item ) {
-		wp_nonce_field( 'orddd_bulk_delete_action', 'orddd_bulk_delete_nonce' );
 		$dd = '';
 		if ( isset( $item->dd ) ) {
 			$dd = $item->dd;


### PR DESCRIPTION
**Cause**
The bulk action forms for Holidays, Blocked Time Slots, and Time Slot Listing reused the current admin URL containing existing query parameters. As a result, WordPress repeatedly appended _wp_http_referer and nonce values on each submission, leading to excessively long URLs and unreliable bulk action behavior.

**Fix**
Cleaned the form action URLs for the Holidays, Blocked Time Slots, and Time Slot Listing sections using remove_query_arg() to strip existing query parameters before submission. This prevents duplicate _wp_http_referer and nonce values from being appended repeatedly.

**Testing**

1. Navigated to Order Delivery Date Lite → Settings → Holidays
2. Selected one or more holidays
3. Applied Delete bulk action
4. Verified the URL remained clean and the selected holidays were deleted successfully

**Repeated the same steps for:**
1. Blocked Time Slots
2. Time Slot Listing

Fix #679