### PR TITLE
UI/UX improvements for Delivery Calendar pop-up layout

### DIFF
--- a/css/order-delivery-date.css
+++ b/css/order-delivery-date.css
@@ -160,7 +160,7 @@ a.qtip-close.qtip-icon span.ui-icon.ui-icon-close {
 .orddd-popup-body {
   display: flex;
   gap: 16px;
-  padding: 20px 20px 11px;
+  padding: 20px 20px 0px;
 }
 
 .orddd-product-image {
@@ -195,9 +195,9 @@ a.qtip-close.qtip-icon span.ui-icon.ui-icon-close {
 }
 
 .orddd-row {
-  font-size: 14px;
+  font-size: 13px;
   color: #444;
-  margin-bottom: 18px;
+  margin-bottom: 12px;
 }
 
 /* Button */
@@ -216,4 +216,12 @@ a.qtip-close.qtip-icon span.ui-icon.ui-icon-close {
 
 .orddd-view-order:hover {
   background: #dbe9ff;
+}
+i.dashicons-archive {
+    height: 0px !important;
+    margin-left: -2px;
+    margin-right: 0px;
+    font-size: 17px;
+    text-align: left;
+    line-height: normal;
 }

--- a/includes/settings/class-orddd-lite-delivery-calendar.php
+++ b/includes/settings/class-orddd-lite-delivery-calendar.php
@@ -79,7 +79,7 @@ class orddd_lite_class_view_deliveries {
 	            $content .= '
 					<div class="orddd-popup-details">
 						<div class="orddd-product-name">
-							<i class="fa-solid fa-cube"></i>
+							<i class="dashicons dashicons-archive"></i>
 							' . esc_html( $product_name ) . '
 							<span class="qty">x' . esc_html( $product_quantity ) . '</span>
 						</div>
@@ -194,7 +194,7 @@ class orddd_lite_class_view_deliveries {
 	            }
 	            $content .= '
 						<div class="orddd-row">
-							<i class="fas fa-cube"></i>
+							<i class="dashicons dashicons-archive"></i>
 							' . wp_kses_post( $product_name ) . '
 						</div>
 					</div>


### PR DESCRIPTION
UI/UX improvements for Delivery Calendar pop-up layout:

<img width="1176" height="584" alt="image" src="https://github.com/user-attachments/assets/24e75392-9ae5-4bb9-97dd-0feafaa9eb18" />


Fix #677