### PR TITLE
Fix fatal error when Email Manager class is not loaded

### DIFF
--- a/emails/class-orddd-lite-email-update-date.php
+++ b/emails/class-orddd-lite-email-update-date.php
@@ -22,6 +22,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 class ORDDD_Lite_Email_Update_Date extends WC_Email {
 
 	/**
+	 * Order ID.
+	 *
+	 * @var int
+	 */
+	public $order_id;
+
+	/**
+	 * Updated by.
+	 *
+	 * @var string
+	 */
+	public $updated_by;
+	/**
 	 * Constructor.
 	 *
 	 * Defines class variables and hooks as needed.

--- a/order_delivery_date.php
+++ b/order_delivery_date.php
@@ -54,6 +54,7 @@ require_once 'includes/class-orddd-lite-process.php';
 require_once 'includes/settings/class-orddd-lite-filter.php';
 require_once 'includes/class-orddd-lite-privacy.php';
 require_once 'includes/settings/class-orddd-lite-delivery-calendar.php';
+require_once 'includes/class-orddd-lite-email-manager.php';
 require_once 'includes/class-orddd-lite-admin-delivery.php';
 require_once 'includes/settings/class-delivery-calendar-event-json.php';
 if ( 'on' === get_option( 'orddd_lite_enable_delivery_date' ) ) {


### PR DESCRIPTION
**Cause**

1. `ORDDD_Lite_Email_Manager` was instantiated before its class file was loaded, causing a fatal error.
2. Dynamic properties ($order_id, $updated_by) were created in `ORDDD_Lite_Email_Update_Date`, triggering PHP 8.2 deprecation warnings.

**Fix**

1. Added `require_once 'includes/class-orddd-lite-email-manager.php';` to ensure the class is loaded before use.
2. Declared class properties in `ORDDD_Lite_Email_Update_Date` to prevent dynamic property creation warnings.

Fix #690