### PR TITLE
Fixed security vulnerability reported by patchstack

### DIFF
--- a/includes/settings/class-orddd-lite-delivery-calendar.php
+++ b/includes/settings/class-orddd-lite-delivery-calendar.php
@@ -223,6 +223,34 @@ class orddd_lite_class_view_deliveries {
 
 	public static function orddd_data_export() {
 		global $wpdb;
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		// Capability check.
+		if ( ! current_user_can( 'manage_woocommerce' ) && ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Check required params.
+		if ( ! isset( $_GET['download'], $_GET['page'] ) ) {
+			return;
+		}
+
+		// Nonce verification.
+		if ( ! isset( $_GET['orddd_export_nonce'] ) || 
+			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['orddd_export_nonce'] ) ), 'orddd_export_nonce' ) ) {
+			wp_die( esc_html__( 'Security check failed.', 'order-delivery-date' ) );
+		}
+
+		$download = sanitize_text_field( wp_unslash( $_GET['download'] ) );
+		$page     = sanitize_text_field( wp_unslash( $_GET['page'] ) );
+
+		// Allowed downloads only.
+		$allowed_downloads = array( 'orddd_data.csv', 'orddd_data.print' );
+		if ( ! in_array( $download, $allowed_downloads, true ) ) {
+			return;
+		}
 		if ( isset( $_GET['download'] ) && ( $_GET['download'] == 'orddd_data.csv' ) && ( ( isset( $_GET['page'] ) && $_GET['page'] = 'orddd_view_orders' ) ) ) {
 			$report = self::orddd_generate_data();
 			$csv    = self::orddd_generate_csv( $report );
@@ -356,25 +384,65 @@ class orddd_lite_class_view_deliveries {
 			$id               = 'id';
 		}
 
-		$orddd_query = "SELECT DISTINCT wp.{$id}, {$post_status}, wpm1.meta_value AS orddd_timestamp , wpm2.meta_value AS delivery_date , wpm3.meta_value AS time_slot
-			FROM `" . $wpdb->prefix . "$order_table` wp
-			INNER JOIN `" . $wpdb->prefix . "$order_meta_table` wpm1 ON ( wp.{$id} = wpm1.{$post_id} AND wpm1.meta_key ='" . $order_timestamp_key . "' )
-			LEFT JOIN `" . $wpdb->prefix . "$order_meta_table` wpm2 ON ( wp.{$id} = wpm2.{$post_id} AND ( wpm2.meta_key ='" . $orddd_delivery_date_key . "' ) )
-			LEFT JOIN `" . $wpdb->prefix . "$order_meta_table` wpm3 ON ( wp.{$id} = wpm3.{$post_id} AND wpm3.meta_key ='_orddd_time_slot' ) ";
+		$order_status = array_map( 'sanitize_text_field', (array) $order_status );
+		$order_status = array_filter( $order_status );
 
-			$orddd_query = apply_filters( 'orddd_lite_calendar_join_filter', $orddd_query );
+		if ( empty( $order_status ) ) {
+			return array();
+		}
 
-			$orddd_query .= "WHERE $post_type = 'shop_order' AND $post_status IN ( '" . implode( "','", $order_status ) . "')
-			AND 
-			(
-			( wpm1.meta_key = '" . $order_timestamp_key . "' AND wpm1.meta_value >= '" . $event_start_timestamp . "' AND wpm1.meta_value <= '" . $event_end_timestamp . "' ) OR 
-			( wpm2.meta_key = '" . $delivery_date_field_label . "' AND STR_TO_DATE( wpm2.meta_value, '" . $date_str . "' ) >= '" . $event_start . "' AND STR_TO_DATE( wpm2.meta_value, '" . $date_str . "' ) <= '" . $event_end . "' )
-			OR ( wpm2.meta_key = '" . $delivery_date_field_label . "' AND STR_TO_DATE( wpm2.meta_value, '" . $date_str . "' ) >= '" . $event_start . "' AND STR_TO_DATE( wpm2.meta_value, '" . $date_str . "' ) <= '" . $event_end . "' ) 
-			OR ( wpm2.meta_key = '" . $orddd_delivery_date_key . "' AND STR_TO_DATE( wpm2.meta_value, '" . $date_str . "' ) >= '" . $event_start . "' AND STR_TO_DATE( wpm2.meta_value, '" . $date_str . "' ) <= '" . $event_end . "' )
-			)";
+		$status_placeholders = implode( ',', array_fill( 0, count( $order_status ), '%s' ) );
 
-			$orddd_query = apply_filters( 'orddd_lite_calendar_where_filter', $orddd_query );
-			$results     = $wpdb->get_results( $orddd_query );// nosemgrep:audit.php.wp.security.sqli.input-in-sinks
+		$event_start = ! empty( $event_start ) ? date( 'Y-m-d', strtotime( $event_start ) ) : '';
+		$event_end   = ! empty( $event_end ) ? date( 'Y-m-d', strtotime( $event_end ) ) : '';
+
+		$event_start_timestamp = ! empty( $event_start_timestamp ) ? intval( $event_start_timestamp ) : 0;
+		$event_end_timestamp   = ! empty( $event_end_timestamp ) ? intval( $event_end_timestamp ) : 0;
+
+		$query = "
+			SELECT DISTINCT wp.{$id}, {$post_status}, 
+				wpm1.meta_value AS orddd_timestamp, 
+				wpm2.meta_value AS delivery_date, 
+				wpm3.meta_value AS time_slot
+			FROM `{$wpdb->prefix}{$order_table}` wp
+			INNER JOIN `{$wpdb->prefix}{$order_meta_table}` wpm1 
+				ON ( wp.{$id} = wpm1.{$post_id} AND wpm1.meta_key = %s )
+			LEFT JOIN `{$wpdb->prefix}{$order_meta_table}` wpm2 
+				ON ( wp.{$id} = wpm2.{$post_id} AND wpm2.meta_key = %s )
+			LEFT JOIN `{$wpdb->prefix}{$order_meta_table}` wpm3 
+				ON ( wp.{$id} = wpm3.{$post_id} AND wpm3.meta_key = %s )
+			WHERE {$post_type} = %s
+			AND {$post_status} IN ($status_placeholders)
+			AND (
+				( wpm1.meta_value >= %d AND wpm1.meta_value <= %d )
+				OR
+				( STR_TO_DATE( wpm2.meta_value, %s ) >= %s 
+				  AND STR_TO_DATE( wpm2.meta_value, %s ) <= %s )
+			)
+		";
+
+		// Prepare values.
+		$query_args = array_merge(
+			array(
+				$order_timestamp_key,
+				$orddd_delivery_date_key,
+				'_orddd_time_slot',
+				'shop_order',
+			),
+			$order_status,
+			array(
+				$event_start_timestamp,
+				$event_end_timestamp,
+				$date_str,
+				$event_start,
+				$date_str,
+				$event_end,
+			)
+		);
+
+		$prepared_query = $wpdb->prepare( $query, $query_args );
+		$prepared_query = apply_filters( 'orddd_lite_calendar_where_filter', $prepared_query );
+		$results        = $wpdb->get_results( $prepared_query );
 
 		$report = array();
 		$i      = 0;

--- a/js/orddd-lite-view-calendar.js
+++ b/js/orddd-lite-view-calendar.js
@@ -46,7 +46,7 @@ let calendar_element;
 					orddd_this_href = cpurl + '/admin.php?page=order_delivery_date_lite&action=view-orders&download=orddd_data.csv';
 				}
 
-				return orddd_this_href + '&eventType=' + jQuery( ".orddd_filter_delivery_calendar" ).val() + '&orderStatus=' + jQuery( ".orddd_filter_by_order_status" ).val() + '&orderShipping=' + jQuery( ".orddd_filter_by_order_shipping" ).val() + '&start=' + start_date + "&end=" + end_date;
+				return orddd_this_href + '&orddd_export_nonce=' + encodeURIComponent(orddd_calendar_js.orddd_export_nonce) + '&eventType=' + jQuery( ".orddd_filter_delivery_calendar" ).val() + '&orderStatus=' + jQuery( ".orddd_filter_by_order_status" ).val() + '&orderShipping=' + jQuery( ".orddd_filter_by_order_shipping" ).val() + '&start=' + start_date + "&end=" + end_date;
 			});
 		},
 
@@ -345,7 +345,7 @@ let calendar_element;
 							orddd_this_href = cpurl + '/admin.php?page=order_delivery_date_lite&action=view-orders&download=orddd_data.csv';
 						}
 
-						return orddd_this_href + '&eventType=' + jQuery(".orddd_filter_delivery_calendar").val() + '&orderStatus=' + jQuery(".orddd_filter_by_order_status").val() + '&orderShipping=' + jQuery(".orddd_filter_by_order_shipping").val() + '&start=' + start_date + "&end=" + end_date;
+						return orddd_this_href + '&orddd_export_nonce=' + encodeURIComponent(orddd_calendar_js.orddd_export_nonce) + '&eventType=' + jQuery(".orddd_filter_delivery_calendar").val() + '&orderStatus=' + jQuery(".orddd_filter_by_order_status").val() + '&orderShipping=' + jQuery(".orddd_filter_by_order_shipping").val() + '&start=' + start_date + "&end=" + end_date;
 					});
 				}
 			});

--- a/order_delivery_date.php
+++ b/order_delivery_date.php
@@ -664,6 +664,7 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 					'pluginurl'           => admin_url() . 'admin.php?action=orddd-delivery-calendar-event-json&vendor_id=0&security='.wp_create_nonce( 'orddd-delivery-calendar-event-json' ),
 					'security'            => wp_create_nonce( 'orddd-delivery-calendar-event-json' ),
 					'vendor_id'           => 0,
+					'orddd_export_nonce'  => wp_create_nonce( 'orddd_export_nonce' ),
 				);
 
 				wp_localize_script(


### PR DESCRIPTION
In this fix i have Fixed below security vulnerability reported by patch stack:

`The Order Delivery Date for WooCommerce plugin provides a Delivery Calendar feature that allows administrators to view and manage delivery dates for orders. The plugin registers a handler for the `orddd-delivery-calendar-event-json` action that retrieves orders based on specified date ranges and order statuses. This handler is accessible to unauthenticated users via the WordPress `init` hook. The `orderStatus` parameter is sanitized using `sanitize_text_field()` but is then directly interpolated into a raw SQL query without proper escaping using `$wpdb->prepare()`. This allows an unauthenticated attacker to inject malicious SQL syntax via the `orderStatus` parameter to perform time-based blind SQL injection. An attacker can extract sensitive data from the database, including administrator password hashes, customer PII, and other confidential information stored in WordPress tables.`

Fix #695 

**Testing Instructions:**

1. Test 'Print' & 'CSV' button functionality on delivery calendar Tab page.

Ticket : https://support.tychesoftwares.com/conversation/15284?folder_id=3