### PR TITLE
Fix: Forward delivery date & time slot to Apple Pay / Google Pay orders

### DIFF
--- a/js/express-checkout-delivery-date.js
+++ b/js/express-checkout-delivery-date.js
@@ -1,0 +1,46 @@
+// File: your-bridge-plugin/assets/express-checkout-delivery-date.js
+
+( function () {
+    // Wait until wp.hooks is available (loaded by WooPayments).
+    function init() {
+        if ( ! window.wp || ! window.wp.hooks ) {
+            return;
+        }
+
+        wp.hooks.addFilter(
+            'wcpay.express-checkout.cart-place-order-extension-data',
+            'orddd/express-checkout-delivery-date',
+            function ( extensionData ) {
+                // Read the delivery date the shopper selected in the datepicker.
+                // e_deliverydate = the formatted display value (e.g. "23/05/2026")
+                // h_deliverydate = the machine-readable value used for timestamps
+                var eDate = document.getElementById( 'e_deliverydate' );
+                var hDate = document.getElementById( 'h_deliverydate' );
+                var timeSlot = localStorage.getItem( 'orddd_lite_time_slot' );
+
+                //console.log(eDate);
+
+                if ( ! eDate || ! eDate.value ) {
+                    // No date selected — return unchanged.
+                    return extensionData;
+                }
+
+                return Object.assign( {}, extensionData, {
+                    'order-delivery-date': {
+                        e_deliverydate:       eDate.value,
+                        h_deliverydate:       hDate ? hDate.value : eDate.value,
+                        orddd_lite_time_slot: timeSlot,
+                    }
+                } );
+            }
+        );
+    }
+
+    // The filter must be registered before the ECE JS fires.
+    // DOMContentLoaded is early enough.
+    if ( document.readyState === 'loading' ) {
+        document.addEventListener( 'DOMContentLoaded', init );
+    } else {
+        init();
+    }
+} )();

--- a/js/express-checkout-delivery-date.js
+++ b/js/express-checkout-delivery-date.js
@@ -11,26 +11,25 @@
             'wcpay.express-checkout.cart-place-order-extension-data',
             'orddd/express-checkout-delivery-date',
             function ( extensionData ) {
-                // Read the delivery date the shopper selected in the datepicker.
-                // e_deliverydate = the formatted display value (e.g. "23/05/2026")
-                // h_deliverydate = the machine-readable value used for timestamps
-                var eDate = document.getElementById( 'e_deliverydate' );
-                var hDate = document.getElementById( 'h_deliverydate' );
+                var eDate    = document.getElementById( 'e_deliverydate' );
+                var hDate    = document.getElementById( 'h_deliverydate' );
                 var timeSlot = localStorage.getItem( 'orddd_lite_time_slot' );
 
-                //console.log(eDate);
-
                 if ( ! eDate || ! eDate.value ) {
-                    // No date selected — return unchanged.
                     return extensionData;
                 }
 
+                var deliveryData = {
+                    e_deliverydate: eDate.value,
+                    h_deliverydate: hDate ? hDate.value : eDate.value,
+                };
+
+                if ( timeSlot && timeSlot !== '' && timeSlot !== 'select' && timeSlot !== 'choose' && timeSlot !== 'NA' ) {
+                    deliveryData.orddd_lite_time_slot = timeSlot;
+                }
+
                 return Object.assign( {}, extensionData, {
-                    'order-delivery-date': {
-                        e_deliverydate:       eDate.value,
-                        h_deliverydate:       hDate ? hDate.value : eDate.value,
-                        orddd_lite_time_slot: timeSlot,
-                    }
+                    'order-delivery-date': deliveryData
                 } );
             }
         );

--- a/order_delivery_date.php
+++ b/order_delivery_date.php
@@ -795,6 +795,14 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 				);
 				wp_localize_script( 'accessibility-orddd', 'orddd_lite_access', $accessibility_args );
 				wp_enqueue_script( 'accessibility-orddd' );
+
+				wp_enqueue_script(
+			        'orddd-wcpay-express-bridge',
+			        plugin_dir_url( __FILE__ ) . 'js/express-checkout-delivery-date.js',
+			        [ 'wp-hooks' ],   // wp-hooks is already enqueued by WooPayments.
+			        time(),
+			        false
+			    );
 			}
 		}
 


### PR DESCRIPTION
**Note:** Issue only replicated with woopayments plugin by woocommerce plugin.

**Cause:**
When paying via Apple Pay or Google Pay, the WooCommerce classic checkout form is never submitted. The delivery date and time slot fields added by the Order Delivery Date plugin are never posted, so they are silently dropped from the order.

**Fix:**

1. Added a JS filter on `wcpay.express-checkout.cart-place-order-extension-data` that reads `#e_deliverydate` and `#h_deliverydate` from the DOM and `orddd_lite_time_slot` from localStorage, then injects them into `extensions['order-delivery-date']` before the order is posted to the Store API.
2. The existing `ORDDD_Lite_Delivery_Blocks` handler already listens to `woocommerce_store_api_checkout_update_order_from_request` and saves those values to order meta, so no PHP changes are needed.

Fix #702 