### PR TITLE
Fix fatal error when restoring non-order posts with HPOS enabled

### DIFF
--- a/includes/class-orddd-lite-common.php
+++ b/includes/class-orddd-lite-common.php
@@ -1545,7 +1545,10 @@ class Orddd_Lite_Common {
 			return false;
 		}
 		if ( self::is_hpos_enabled() ) {
-			$order       = wc_get_order( $order_id );
+			$order = wc_get_order( $order_id );
+			if ( ! $order || ! $order instanceof WC_Order ) {
+				return false;
+			}
 			$post_status = $order->get_status();
 			$post_type   = $order->get_type();
 		} else {


### PR DESCRIPTION
Added a validation check for the order object in `orddd_lite_untrash_order()` to prevent a fatal error when `wc_get_order()` returns false while restoring posts with HPOS enabled. This ensures the function only proceeds for valid WooCommerce orders.

Fix #704