### PR TITLE
Fix(security): removed global manage_options grant to shop_manager role

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 *** Order Delivery Date for WooCommerce ***
+2026-07-22 - version 4.6.1
+* Security - Fixed a privilege escalation issue where the shop_manager role could incorrectly receive the manage_options capability.
+
 2026-07-13 - version 4.6.0
 * Fix - Resolved an issue where delivery date validation failed for orders placed via WooCommerce Stripe Express Checkout (Google Pay), despite a delivery date being selected.
 * Fix - Resolved an error reported when retrieving a deleted order from the Trash.

--- a/order_delivery_date.php
+++ b/order_delivery_date.php
@@ -4,13 +4,13 @@
  * Plugin URI: https://www.tychesoftwares.com/store/premium-plugins/order-delivery-date-for-woocommerce-pro-21/
  * Description: This plugin allows customers to choose their preferred Order Delivery Date during checkout.
  * Author: Tyche Softwares
- * Version: 4.6.0
+ * Version: 4.6.1
  * Author URI: https://www.tychesoftwares.com/
  * Contributor: Tyche Softwares, https://www.tychesoftwares.com/
  * Text Domain: order-delivery-date
  * Requires PHP: 7.3
  * WC requires at least: 3.0.0
- * WC tested up to: 10.9.3
+ * WC tested up to: 10.9.4
  * Requires Plugins: woocommerce
  *
  * @package  Order-Delivery-Date-Lite-for-WooCommerce
@@ -21,7 +21,7 @@
  *
  * @since 1.0
  */
-$wpefield_version = '4.6.0';
+$wpefield_version = '4.6.1';
 
 /**
  * Template path.
@@ -86,7 +86,7 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 
 			add_action( 'init', array( &$this, 'orddd_lite_update_po_file' ) );
 			add_action( 'admin_init', array( &$this, 'orddd_lite_update_db_check' ) );
-			add_action( 'admin_init', array( &$this, 'orddd_lite_capabilities' ) );
+			add_action( 'admin_init', array( &$this, 'orddd_lite_remove_legacy_manage_options_cap' ) );
 			add_action( 'admin_init', array( &$this, 'orddd_lite_check_if_woocommerce_active' ) );
 
 			// Settings.
@@ -341,7 +341,7 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 		 */
 		public function orddd_lite_update_db_check() {
 			global $wpefield_version;
-			if ( '4.6.0' === $wpefield_version ) {
+			if ( '4.6.1' === $wpefield_version ) {
 				self::orddd_lite_update_install();
 			}
 		}
@@ -373,16 +373,22 @@ if ( ! class_exists( 'order_delivery_date_lite' ) ) {
 
 
 		/**
-		 * Capability to allow shop manager to edit settings
+		 * One-time security remediation: removes the unintended `manage_options` capability from the `shop_manager` role.
 		 *
 		 * @hook admin_init
-		 * @since 2.2
+		 * @since 4.6.0
 		 */
-		public function orddd_lite_capabilities() {
-			$role = get_role( 'shop_manager' );
-			if ( isset( $role ) && '' !== $role ) {
-				$role->add_cap( 'manage_options' );
+		public function orddd_lite_remove_legacy_manage_options_cap() {
+			if ( 'yes' === get_option( 'orddd_lite_shop_manager_cap_cleaned', 'no' ) ) {
+				return;
 			}
+
+			$role = get_role( 'shop_manager' );
+			if ( $role instanceof WP_Role && $role->has_cap( 'manage_options' ) ) {
+				$role->remove_cap( 'manage_options' );
+			}
+
+			update_option( 'orddd_lite_shop_manager_cap_cleaned', 'yes' );
 		}
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://www.paypal.me/TycheSoftwares
 Author URI: https://www.tychesoftwares.com/
 Tags: delivery date, delivery time, preparation time, woocommerce, pickup date
 Requires at least: 1.3
-Tested up to: 7.0.1
-Stable tag: 4.6.0
+Tested up to: 7.0.2
+Stable tag: 4.6.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -181,6 +181,9 @@ Option 3:
 This plugin communicates with our tracking server to send usage data **only** if the user has explicitly opted in to usage tracking. For detailed information about what is tracked, please refer to our [usage tracking documentation](https://www.tychesoftwares.com/docs/woocommerce-order-delivery-date-lite/order-delivery-lite-usage-tracking/).
 
 == Changelog ==
+
+= 4.6.1 (22.07.2026)
+* Security - Fixed a privilege escalation issue where the shop_manager role could incorrectly receive the manage_options capability.
 
 = 4.6.0 (14.07.2026)
 * Fix - Resolved an issue where delivery date validation failed for orders placed via WooCommerce Stripe Express Checkout (Google Pay), despite a delivery date being selected.

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,6 +13,14 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
+// Security cleanup: strip the legacy site-wide `manage_options` capability that
+// versions <= 4.5.3 added to the shop_manager role, and drop our tracking flag.
+$orddd_lite_shop_manager = get_role( 'shop_manager' );
+if ( $orddd_lite_shop_manager instanceof WP_Role && $orddd_lite_shop_manager->has_cap( 'manage_options' ) ) {
+	$orddd_lite_shop_manager->remove_cap( 'manage_options' );
+}
+delete_option( 'orddd_lite_shop_manager_cap_cleaned' );
+
 delete_option( 'orddd_lite_db_version' );
 delete_option( 'orddd_lite_enable_delivery_date' );
 


### PR DESCRIPTION
The plugin granted the site-wide `manage_options` capability to the WooCommerce `shop_manager` role on every admin request via `orddd_lite_capabilities()`, letting Shop Managers pass administrator-only checks across WordPress and other plugins. The change persisted in the role definition and was never cleaned up.

The grant was legacy and unnecessary — all ORDD admin pages already run on `manage_woocommerce`.

**Changes**
- `order_delivery_date.php`: removed the grant; replaced it with a one-time, option-guarded cleanup that *removes* `manage_options` from `shop_manager` and never re-mutates the role.
- `uninstall.php`: strips the cap and deletes the tracking flag on uninstall.

Fix #710